### PR TITLE
BUG-01: eliminar metadata social residual de Bolt

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,9 +6,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>La Colorada — Pizzas, Empanadas & Comidas Caseras | La Horqueta, San Isidro</title>
     <meta name="description" content="La Colorada: pizza de molde, empanadas cruzadas y comida casera en la Galería Colorada, La Horqueta, Beccar, San Isidro. Hacé tu pedido por WhatsApp." />
-    <meta property="og:image" content="https://bolt.new/static/og_default.png" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:image" content="https://bolt.new/static/og_default.png" />
+    <link rel="canonical" href="https://la-colorada-web-bolt.vercel.app/" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="es_AR" />
+    <meta property="og:site_name" content="La Colorada" />
+    <meta property="og:title" content="La Colorada — Pizzas, Empanadas & Comidas Caseras" />
+    <meta property="og:description" content="Pizza de molde, empanadas cruzadas y comida casera en La Horqueta, San Isidro. Hacé tu pedido por WhatsApp." />
+    <meta property="og:url" content="https://la-colorada-web-bolt.vercel.app/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="La Colorada — Pizzas, Empanadas & Comidas Caseras" />
+    <meta name="twitter:description" content="Pizza de molde, empanadas cruzadas y comida casera en La Horqueta, San Isidro. Hacé tu pedido por WhatsApp." />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Resumen
- elimina las referencias de og:image y twitter:image a bolt.new
- agrega URL canónica y metadata Open Graph propia de La Colorada
- conserva el título y la descripción existentes
- usa tarjeta social sin imagen hasta contar con un recurso propio aprobado

## Verificación
- npm run typecheck
- npm run lint (0 errores; 2 warnings heredados en src/cart.tsx)
- npm run build
- HTML generado sin referencias a bolt.new
- Vercel Preview: success

Preview: https://la-colorada-web-bolt-ns0frshzo-mati-agile-team.vercel.app
Trello: https://trello.com/c/KKTseqJT