### PR TITLE
Corregir horario de cierre a las 23:00

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
               "Sunday"
             ],
             "opens": "19:00",
-            "closes": "23:50"
+            "closes": "23:00"
           }
         ],
         "sameAs": [

--- a/src/components/Location.tsx
+++ b/src/components/Location.tsx
@@ -23,7 +23,7 @@ export function Location() {
     {
       icon: Clock,
       title: 'Horarios',
-      lines: ['Lunes a Domingos', '11:30 a 14:30 · 19:00 a 23:50'],
+      lines: ['Lunes a Domingos', '11:30 a 14:30 · 19:00 a 23:00'],
     },
     {
       icon: Phone,


### PR DESCRIPTION
## Cambio
- corrige el horario nocturno visible de 23:50 a 23:00
- mantiene sincronizado el JSON-LD Restaurant para Google

## Verificación
- npm run typecheck
- npm run lint (2 warnings preexistentes)
- npm run build
- Vercel Preview: success