### PR TITLE
Configurar base del backlog en GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Bug
+description: Comportamiento incorrecto o regresión
+title: "BUG-__: "
+labels:
+  - "type: bug"
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problema observado
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidencia y pasos para reproducir
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Resultado esperado
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de aceptación
+      placeholder: "- [ ] Corrección verificada"
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/spike.yml
+++ b/.github/ISSUE_TEMPLATE/spike.yml
@@ -1,0 +1,36 @@
+name: Spike
+description: Investigación acotada para reducir incertidumbre
+title: "SPIKE-__: "
+labels:
+  - "type: spike"
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Pregunta o incertidumbre
+    validations:
+      required: true
+  - type: textarea
+    id: research
+    attributes:
+      label: Alcance de la investigación
+    validations:
+      required: true
+  - type: input
+    id: timebox
+    attributes:
+      label: Timebox
+      placeholder: Una sesión enfocada
+    validations:
+      required: true
+  - type: textarea
+    id: deliverable
+    attributes:
+      label: Evidencia y decisión esperada
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Fuera de alcance
+

--- a/.github/ISSUE_TEMPLATE/user-story.yml
+++ b/.github/ISSUE_TEMPLATE/user-story.yml
@@ -1,0 +1,44 @@
+name: User Story
+description: Nueva necesidad de producto para La Colorada
+title: "US-__: "
+labels:
+  - "type: story"
+body:
+  - type: textarea
+    id: story
+    attributes:
+      label: Historia
+      description: "Como... quiero... para..."
+      placeholder: "Como cliente de La Colorada, quiero... para..."
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto y problema
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Alcance
+      description: Incluí también lo que queda afuera cuando sea relevante.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Criterios de aceptación
+      placeholder: "- [ ] Resultado verificable"
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencias y decisiones pendientes
+  - type: textarea
+    id: estimate
+    attributes:
+      label: Estimación
+      description: Tamaño, consumo Codex esperado, confianza y participación humana.
+


### PR DESCRIPTION
## Qué incluye
- plantillas de Issues para User Story, Bug y Spike
- etiquetas por tipo de trabajo
- GitHub Project privado vinculado al repositorio, con flujo y campos de estimación/consumo

## Hitos
- Hito 1: inventario y mapeo del backlog completados (31 tarjetas; 23 en backlog y 7 publicadas)
- Hito 2: configuración base completada con este PR
- No se migraron todavía las stories: eso comienza con el piloto del hito 3

## Validación
- npm run typecheck
- npm run lint (0 errores; 2 warnings preexistentes en src/cart.tsx)
- npm run build
- YAML de las tres plantillas validado