### PR TITLE
Completar cutover del backlog a GitHub

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # Development rules
 
+- The canonical product backlog is the GitHub Project **La Colorada · Backlog**:
+  https://github.com/users/matiasgbq/projects/2
+- GitHub Issues and Project fields are the source of truth for scope, priority,
+  estimates, status, and traceability. Trello is historical and must not be
+  used for new work or current-state decisions.
+- Before proposing, prioritizing, or starting work, inspect the Project and
+  search existing Issues to avoid duplicates.
+- Matías is the Product Owner. Codex is the coordinating agent: clarify product
+  intent, identify dependencies and risks, delegate only bounded work, verify
+  results, and keep material decisions under human approval.
+- Update the relevant Issue and Project status as work progresses. Do not mark
+  work published without merge and production evidence when deployment applies.
+- Record experimental Codex estimates and actual usage separately; do not
+  present total process consumption as pure implementation cost.
 - Stack: React 18, TypeScript, Vite, and Tailwind CSS.
 - Use `@/` imports for modules under `src/`.
 - Prefer `lucide-react` for icons before adding another icon library.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@ Sitio de La Colorada mantenido con **Codex**, versionado en **GitHub** y publica
 
 - Producción: https://la-colorada-web-bolt.vercel.app
 - Repositorio: https://github.com/matiasgbq/La-Colorada-web-bolt
+- Backlog: https://github.com/users/matiasgbq/projects/2
+
+## Gestión del producto
+
+El GitHub Project **La Colorada · Backlog** es la fuente única de verdad para
+iniciativas, historias, bugs, spikes, prioridades, estimaciones y estados.
+
+- Matías actúa como Product Owner: define objetivos, prioridades y aprobaciones.
+- Codex actúa como agente coordinador: refina, organiza, ejecuta o delega,
+  verifica resultados y explica las implicancias técnicas.
+- Los Issues contienen el alcance y la trazabilidad de cada trabajo.
+- El Project muestra el estado operativo y la planificación vigente.
+- El tablero anterior de Trello queda únicamente como archivo histórico.
+
+Antes de iniciar trabajo, buscar un Issue existente para evitar duplicados. Las
+ideas nuevas se registran usando las plantillas de User Story, Bug o Spike y se
+incorporan al Project antes de ejecutarlas.
 
 ## Stack
 
@@ -48,10 +65,11 @@ todo archivo de imagen compatible se publica en el carrusel.
 
 ## Flujo de trabajo
 
-1. Crear o reutilizar una rama `codex/*` basada en `main`.
-2. Implementar y verificar localmente con Codex.
-3. Publicar una pull request para obtener una preview de Vercel.
-4. Revisar y aprobar.
-5. Integrar en `main`; Vercel mantiene la publicación de producción.
+1. Elegir y refinar un Issue del GitHub Project.
+2. Crear o reutilizar una rama `codex/*` basada en `main`.
+3. Implementar y verificar localmente con Codex.
+4. Publicar una pull request para obtener una preview de Vercel.
+5. Revisar y aprobar.
+6. Integrar en `main`, verificar producción y actualizar el Issue y el Project.
 
 Bolt ya no es necesario para desarrollar o mantener el proyecto.


### PR DESCRIPTION
## Qué cambia
- declara GitHub Project como fuente única de verdad del producto
- documenta roles de Product Owner y agente coordinador
- incorpora el backlog al flujo de trabajo del repositorio
- marca Trello como archivo histórico
- agrega reglas operativas para Codex y futuros agentes

## Cutover externo
- GitHub Project actualizado con la gobernanza definitiva
- 23 tarjetas activas de Trello auditadas: 13 continúan activas y 10 quedaron cerradas/no planificadas
- tarjeta principal de Trello convertida en aviso de archivo histórico
- Trello conservado sin borrar tarjetas

## Validación
- npm run typecheck
- npm run lint (0 errores; 2 warnings preexistentes en src/cart.tsx)
- npm run build
- git diff --check